### PR TITLE
job inputs type can be different from job's type

### DIFF
--- a/karadoc/common/job_core/has_inputs.py
+++ b/karadoc/common/job_core/has_inputs.py
@@ -131,10 +131,14 @@ class HasInputs(HasSpark, JobBase, ABC):
         :param read_options: Optional, options passed to the DataFrameReader.
         :return: a spark Dataframe
         """
-        from karadoc.common.job_core.load import load_non_runnable_action_file
+        from karadoc.common.run import load_populate
+        from karadoc.common.stream import load_stream_file
 
         if input_format is None:
-            input_job = load_non_runnable_action_file(table_full_name, type(self))
+            try:
+                input_job = load_populate(table_full_name)
+            except FileNotFoundError:
+                input_job = load_stream_file(table_full_name)
             input_format = input_job.output_format
 
         df = self._read_path(self.hdfs_input(table_full_name), input_format, schema, read_options)

--- a/karadoc/common/job_core/job_base.py
+++ b/karadoc/common/job_core/job_base.py
@@ -16,4 +16,4 @@ class JobBase:
             (cls._action_file_name_conf_key is not None),
             "_action_file_name variable must be overwritten by the class that extends JobBase",
         )
-        return conf.get_action_file_name(cls._action_file_name_conf_key)
+        return f"{conf.get_action_file_name(cls._action_file_name_conf_key)}.py"

--- a/karadoc/common/job_core/load.py
+++ b/karadoc/common/job_core/load.py
@@ -94,7 +94,7 @@ def __load_action_file(job_type: Type[Job], full_table_name: str, passed_vars: O
     (schema_name, table_name, _) = parse_table_name(full_table_name)
     file_path = file_index.get_action_file(schema_name, table_name, job_type)
     if file_path is None:
-        expected_path = Path(f"**/{schema_name}.db") / table_name / f"{job_type.get_action_file_name()}.py"
+        expected_path = Path(f"**/{schema_name}.db") / table_name / f"{job_type.get_action_file_name()}"
         raise FileNotFoundError(
             f"Found no file matching the path '{expected_path}' for the table {full_table_name} "
             f"in the directory '{conf.get_model_folder_location()}'"

--- a/karadoc/common/table_utils.py
+++ b/karadoc/common/table_utils.py
@@ -3,7 +3,6 @@ import re
 from typing import List, Optional, Tuple, Type
 
 from karadoc.common.conf import get_model_folder_location
-from karadoc.common.job_core.job_base import JobBase
 from karadoc.common.model import file_index
 
 
@@ -16,10 +15,10 @@ def get_data_location(table_name: str) -> str:
     return "data/hive/warehouse/%s.db/%s" % (schema_name, table_name)
 
 
-def get_folder_location(table_name: str, job_type: Type[JobBase]) -> Optional[str]:
+def get_folder_location(table_name: str) -> Optional[str]:
     (schema_name, table_name, _) = parse_table_name(table_name)
 
-    path = file_index.get_action_file(schema_name, table_name, job_type)
+    path = file_index.get_action_file(schema_name, table_name)
     if path:
         return os.path.split(path)[0]
     else:
@@ -53,8 +52,8 @@ def parse_table_name(table_name: str) -> Tuple[str, str, str]:
         raise ValueError("Incorrect table name : %s" % table_name)
 
 
-def table_exists(table_name: str, job_type: Type[JobBase]) -> bool:
-    folder_location = get_folder_location(table_name, job_type)
+def table_exists(table_name: str) -> bool:
+    folder_location = get_folder_location(table_name)
     if folder_location:
         return os.path.isdir(folder_location)
     else:

--- a/karadoc/common/validations/job_validations.py
+++ b/karadoc/common/validations/job_validations.py
@@ -39,7 +39,7 @@ ValidationResult_JobLoadError = ValidationResultTemplate(
 def validate_inputs(job: Union[HasInputs, JobBase], **_) -> Generator[ValidationResult, None, None]:
     """Check that inputs correspond to inputs managed by karadoc"""
     for input_table in job.list_input_tables():
-        if not table_utils.table_exists(input_table, type(job)):
+        if not table_utils.table_exists(input_table):
             yield ValidationResult_UnknownInput(table=input_table)
 
 

--- a/tests/karadoc/cli/commands/test_quality_check.py
+++ b/tests/karadoc/cli/commands/test_quality_check.py
@@ -281,3 +281,30 @@ class TestQualityCheck(unittest.TestCase):
             }
         )
         self.assertEqual(expected, self.result_df)
+
+    def test_quality_check_has_inputs(self):
+        with mock.patch("tests.resources.connectors.dummy.DummyConnector.write", side_effect=self.write_mock):
+            karadoc.cli.run_command("run --tables test_schema.input_table")
+            karadoc.cli.run_command(
+                "quality_check --output-alert-table test_schema.output_table --tables test_schema.has_inputs"
+            )
+
+        self.result_df.show(1, False)
+
+        expected = MockDataFrame(
+            {
+                MockRow(
+                    alert=MockRow(
+                        table="test_schema.has_inputs",
+                        name="alert_has_inputs",
+                        description="This is a dummy alert generated using inputs tables",
+                        severity="Debug",
+                        evaluation_date=Anything,
+                        status="ko",
+                        rank=Anything,
+                    ),
+                    columns={MockRow(key="id", value="1")},
+                )
+            }
+        )
+        self.assertEqual(expected, self.result_df)

--- a/tests/karadoc/cli/commands/test_run.py
+++ b/tests/karadoc/cli/commands/test_run.py
@@ -221,7 +221,7 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(ActionFileLoadingError) as cm:
             karadoc.cli.run_command("run --tables test_schema.job_init_invalid")
         the_exception = cm.exception
-        self.assertIn("Could not load POPULATE file for table test_schema.job_init_invalid", str(the_exception))
+        self.assertIn("Could not load POPULATE.py file for table test_schema.job_init_invalid", str(the_exception))
         self.assertEqual(
             "Error: the spark context should not be initialized in an action file.", str(the_exception.__cause__)
         )

--- a/tests/karadoc/cli/commands/test_run_with_external_io.py
+++ b/tests/karadoc/cli/commands/test_run_with_external_io.py
@@ -158,7 +158,7 @@ class TestRunWithExternalIO(unittest.TestCase):
             with self.assertRaises(ActionFileLoadingError) as cm:
                 karadoc.cli.run_command("run --dry --tables " + table)
             the_exception = cm.exception
-            self.assertIn(f"Could not load POPULATE file for table {table}", str(the_exception))
+            self.assertIn(f"Could not load POPULATE.py file for table {table}", str(the_exception))
 
     def test_run_with_load_external_inputs_as_view(self):
         """When performing a run of a Populate with external inputs, it should call DummyConnector.read once"""

--- a/tests/karadoc/cli/commands/test_run_with_vars.py
+++ b/tests/karadoc/cli/commands/test_run_with_vars.py
@@ -104,7 +104,7 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(ActionFileLoadingError) as cm:
             karadoc.cli.run_command("run --dry --tables test_schema.var_bad_key_type")
         the_exception = cm.exception
-        self.assertIn("Could not load POPULATE file for table test_schema.var_bad_key_type", str(the_exception))
+        self.assertIn("Could not load POPULATE.py file for table test_schema.var_bad_key_type", str(the_exception))
         self.assertEqual(
             "Only strings are allowed as vars keys. Got key: 1 of type: int instead.", str(the_exception.__cause__)
         )
@@ -123,7 +123,7 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(ActionFileLoadingError) as cm:
             karadoc.cli.run_command("run --dry --tables test_schema.var_bad_value_type")
         the_exception = cm.exception
-        self.assertIn("Could not load POPULATE file for table test_schema.var_bad_value_type", str(the_exception))
+        self.assertIn("Could not load POPULATE.py file for table test_schema.var_bad_value_type", str(the_exception))
         self.assertEqual(
             "Type list of variable 'var_bad' is not supported for variables. "
             "Only the following types are supported ['str', 'bool', 'int', 'float']",
@@ -139,7 +139,7 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(ActionFileLoadingError) as cm:
             karadoc.cli.run_command("run --dry --tables test_schema.var_bad_value_type")
         the_exception = cm.exception
-        self.assertIn("Could not load POPULATE file for table test_schema.var_bad_value_type", str(the_exception))
+        self.assertIn("Could not load POPULATE.py file for table test_schema.var_bad_value_type", str(the_exception))
         self.assertEqual(
             "Type list of variable 'var_bad' is not supported for variables. "
             "Only the following types are supported ['str', 'bool', 'int', 'float']",
@@ -160,7 +160,7 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(ActionFileLoadingError) as cm:
             karadoc.cli.run_command("run --dry --tables test_schema.var_bad_key_type")
         the_exception = cm.exception
-        self.assertIn("Could not load POPULATE file for table test_schema.var_bad_key_type", str(the_exception))
+        self.assertIn("Could not load POPULATE.py file for table test_schema.var_bad_key_type", str(the_exception))
         self.assertEqual(
             "Only strings are allowed as vars keys. Got key: 1 of type: int instead.", str(the_exception.__cause__)
         )

--- a/tests/karadoc/cli/commands/test_stream.py
+++ b/tests/karadoc/cli/commands/test_stream.py
@@ -20,7 +20,7 @@ from karadoc.test_utils.spark import MockDataFrame, MockRow
 # For this reason, we define it here once, then apply it to the class AND the setUp and tearDown methods
 from karadoc.test_utils.stdio import captured_output
 
-warehouse_dir = "test_working_dir/test_run_warehouse"
+warehouse_dir = "test_working_dir/hive/warehouse"
 
 config_mock = mock_settings_for_test_class(
     {
@@ -37,13 +37,13 @@ config_mock = mock_settings_for_test_class(
 class TestStream(unittest.TestCase):
     @config_mock
     def setUp(self) -> None:
-        shutil.rmtree(warehouse_dir, ignore_errors=True)
+        shutil.rmtree(conf.get_warehouse_folder_location(), ignore_errors=True)
         shutil.rmtree(conf.get_streaming_checkpoint_folder_location(), ignore_errors=True)
         shutil.rmtree(conf.get_spark_stream_tmp_dir(), ignore_errors=True)
 
     @config_mock
     def tearDown(self) -> None:
-        shutil.rmtree(warehouse_dir, ignore_errors=True)
+        shutil.rmtree(conf.get_warehouse_folder_location(), ignore_errors=True)
         shutil.rmtree(conf.get_streaming_checkpoint_folder_location(), ignore_errors=True)
         shutil.rmtree(conf.get_spark_stream_tmp_dir(), ignore_errors=True)
 
@@ -94,7 +94,7 @@ class TestStream(unittest.TestCase):
         with self.assertRaises(ActionFileLoadingError) as cm:
             karadoc.cli.run_command("stream --tables test_schema.job_init_invalid --streaming-mode once")
         the_exception = cm.exception
-        self.assertIn("Could not load STREAM file for table test_schema.job_init_invalid", str(the_exception))
+        self.assertIn("Could not load STREAM.py file for table test_schema.job_init_invalid", str(the_exception))
         self.assertEqual(
             "Error: the spark context should not be initialized in an action file.", str(the_exception.__cause__)
         )

--- a/tests/karadoc/cli/commands/test_stream_with_external_io.py
+++ b/tests/karadoc/cli/commands/test_stream_with_external_io.py
@@ -26,6 +26,7 @@ config_mock = mock_settings_for_test_class(
         "model_dir": "tests/resources/karadoc/cli/commands/test_stream_with_external_io/model",
         "spark_stream_dir": "test_working_dir/spark/stream",
         "connection": {"dummy": {"type": "tests.resources.connectors.dummy"}},
+        "warehouse_dir": "test_working_dir/hive/warehouse",
     }
 )
 
@@ -36,11 +37,15 @@ class TestStreamWithExternalIO(PySparkTest):
 
     @config_mock
     def setUp(self) -> None:
-        shutil.rmtree(conf.get_spark_stream_dir(), ignore_errors=True)
+        shutil.rmtree(conf.get_warehouse_folder_location(), ignore_errors=True)
+        shutil.rmtree(conf.get_streaming_checkpoint_folder_location(), ignore_errors=True)
+        shutil.rmtree(conf.get_spark_stream_tmp_dir(), ignore_errors=True)
 
     @config_mock
     def tearDown(self) -> None:
-        shutil.rmtree(conf.get_spark_stream_dir(), ignore_errors=True)
+        shutil.rmtree(conf.get_warehouse_folder_location(), ignore_errors=True)
+        shutil.rmtree(conf.get_streaming_checkpoint_folder_location(), ignore_errors=True)
+        shutil.rmtree(conf.get_spark_stream_tmp_dir(), ignore_errors=True)
 
     def test_stream_with_external_input(self):
         """When we execute a stream with external inputs, it should call DummyConnector.read"""
@@ -149,7 +154,7 @@ class TestStreamWithExternalIO(PySparkTest):
             with self.assertRaises(ActionFileLoadingError) as cm:
                 karadoc.cli.run_command("stream --dry --tables " + table)
             the_exception = cm.exception
-            self.assertIn(f"Could not load STREAM file for table {table}", str(the_exception))
+            self.assertIn(f"Could not load STREAM.py file for table {table}", str(the_exception))
             self.assertIn("should have the following signature", str(the_exception.__cause__))
 
     def test_stream_checkpointing(self):

--- a/tests/resources/karadoc/cli/commands/test_quality_check/model/test_schema.db/has_inputs/QUALITY_CHECK.py
+++ b/tests/resources/karadoc/cli/commands/test_quality_check/model/test_schema.db/has_inputs/QUALITY_CHECK.py
@@ -1,0 +1,17 @@
+from karadoc.common.quality import CheckSeverity, Job, alert
+
+job = Job()
+
+job.inputs = {"input_table": "test_schema.input_table"}
+
+
+def before_all():
+    job.load_inputs_as_views()
+
+
+@alert(
+    description="This is a dummy alert generated using inputs tables",
+    severity=CheckSeverity.Debug,
+)
+def alert_has_inputs():
+    return job.spark.sql(""" SELECT * FROM input_table where id==1""")

--- a/tests/resources/karadoc/cli/commands/test_quality_check/model/test_schema.db/input_table/POPULATE.py
+++ b/tests/resources/karadoc/cli/commands/test_quality_check/model/test_schema.db/input_table/POPULATE.py
@@ -1,0 +1,10 @@
+from pyspark.sql.types import Row
+
+from karadoc.common import Job
+
+job = Job()
+
+
+def run():
+    rows = [Row(id=i) for i in range(2)]
+    return job.spark.createDataFrame(rows)


### PR DESCRIPTION
This is a duplicate of the pull request #5, used to run SonarCloud's quality gateway.

SonarCloud cannot run scans on pull requests submitted from a remote repository, because github actions does not pass secrets (like SONAR_TOKEN) to workflows triggered by a pull request from a fork.
